### PR TITLE
fix respond_to test for protected method

### DIFF
--- a/spec/targeting_spec.rb
+++ b/spec/targeting_spec.rb
@@ -6,7 +6,9 @@ describe FuelSDK::Targeting do
 
   it { should respond_to(:endpoint) }
   it { should_not respond_to(:endpoint=) }
-  it { should respond_to(:determine_stack) }
+  it 'should respond to determine_stack' do
+    expect(subject.respond_to?(:determine_stack, true)).to be_true
+  end
   it { should respond_to(:get) }
   it { should respond_to(:post) }
   it { should respond_to(:patch) }


### PR DESCRIPTION
`should respond_to` doesn't allow you to pass in the `include_all` boolean parameter to check against protected/private methods. (See: http://ruby-doc.org/core-2.1.1/Object.html#method-i-respond_to-3F)

Therefore we need to check against the native `respond_to?` method instead.

@joshuafleck @dawid-sklodowski please review/sign-off
