### PR TITLE
Ability to specify the environment to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,13 @@ If you have not registered your application or you need to lookup your Applicati
 Add a require statement to reference the Fuel SDK's functionality:
 > require 'fuelsdk'
 
-Next, create an instance of the Client class:
-> myClient = FuelSDK::Client.new {'client' => { 'id' => CLIENTID, 'secret' => SECRET }}
+Next, create an instance of the Client class depending on your environment:
+
+For a Sandbox environment
+> myClient = FuelSDK::Client.new {'client' => { 'id' => CLIENTID, 'secret' => SECRET }, "defaultwsdl" => "https://webservice.test.exacttarget.com/etframework.wsdl", "authenticationurl" => "https://auth-test.exacttargetapis.com/v1/requestToken"}
+
+For a Production environment
+> myClient = FuelSDK::Client.new {'client' => { 'id' => CLIENTID, 'secret' => SECRET }, "defaultwsdl" => "https://webservice.exacttarget.com/etframework.wsdl", "authenticationurl" => "https://auth.exacttargetapis.com/v1/requestToken"}
 
 Create an instance of the object type we want to work with:
 > list = FuelSDK::List.new

--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -77,7 +77,7 @@ module FuelSDK
 
 	class Client
 	attr_accessor :debug, :access_token, :auth_token, :internal_token, :refresh_token,
-		:id, :secret, :signature, :package_name, :package_folders, :parent_folders, :auth_token_expiration
+		:id, :secret, :signature, :authurl, :package_name, :package_folders, :parent_folders, :auth_token_expiration
 
 	include FuelSDK::Soap
 	include FuelSDK::Rest
@@ -106,7 +106,8 @@ module FuelSDK
 			self.jwt = params['jwt'] if params['jwt']
 			self.refresh_token = params['refresh_token'] if params['refresh_token']
 
-			self.wsdl = params["defaultwsdl"] if params["defaultwsdl"]
+			self.wsdl = params["defaultwsdl"]
+			self.authurl = params["authenticationurl"]
 		end
 
 		def refresh force=false
@@ -126,7 +127,7 @@ module FuelSDK
 					h['content_type'] = 'application/json'
 					h['params'] = {'legacy' => 1}
 				end
-				response = post("https://auth-test.exacttargetapis.com/v1/requestToken", options)
+				response = post(authurl, options)
 				raise "Unable to refresh token: #{response['message']}" unless response.has_key?('accessToken')
 
 				self.access_token = response['accessToken']

--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -106,8 +106,8 @@ module FuelSDK
 			self.jwt = params['jwt'] if params['jwt']
 			self.refresh_token = params['refresh_token'] if params['refresh_token']
 
-			self.wsdl = params["defaultwsdl"]
-			self.authurl = params["authenticationurl"]
+			self.wsdl = params["defaultwsdl"] if params['defaultwsdl']
+			self.authurl = params["authenticationurl"] if params['authenticationurl']
 		end
 
 		def refresh force=false

--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -126,7 +126,7 @@ module FuelSDK
 					h['content_type'] = 'application/json'
 					h['params'] = {'legacy' => 1}
 				end
-				response = post("https://auth.exacttargetapis.com/v1/requestToken", options)
+				response = post("https://auth-test.exacttargetapis.com/v1/requestToken", options)
 				raise "Unable to refresh token: #{response['message']}" unless response.has_key?('accessToken')
 
 				self.access_token = response['accessToken']

--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -131,7 +131,11 @@ module FuelSDK
 		end
 
 		def wsdl
-			@wsdl ||= 'https://webservice.test.exacttarget.com/Service.asmx?wsdl'
+			@wsdl
+		end
+
+		def authurl
+			@authurl
 		end
 
 		def soap_client

--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -131,7 +131,7 @@ module FuelSDK
 		end
 
 		def wsdl
-			@wsdl ||= 'https://webservice.exacttarget.com/etframework.wsdl'
+			@wsdl ||= 'https://webservice.test.exacttarget.com/Service.asmx?wsdl'
 		end
 
 		def soap_client

--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -131,11 +131,11 @@ module FuelSDK
 		end
 
 		def wsdl
-			@wsdl
+			@wsdl ||= "https://webservice.exacttarget.com/etframework.wsdl"
 		end
 
 		def authurl
-			@authurl
+			@authurl ||= "https://auth.exacttargetapis.com/v1/requestToken"
 		end
 
 		def soap_client


### PR DESCRIPTION
I needed the ability to change the environment to use the sandbox environment, so you can now specify it manually.  If not set it should default to a production environment.