### PR TITLE
Dependency injection for the request token url

### DIFF
--- a/lib/fuelsdk/client.rb
+++ b/lib/fuelsdk/client.rb
@@ -98,11 +98,12 @@ module FuelSDK
 			self.debug = debug
 			client_config = params['client']
 			if client_config
-			self.id = client_config["id"]
-			self.secret = client_config["secret"]
-			self.signature = client_config["signature"]
+        self.id = client_config["id"]
+        self.secret = client_config["secret"]
+        self.signature = client_config["signature"]
 			end
 
+      self.request_token_url = params['request_token_url'] ? params['request_token_url'] : 'https://auth.exacttargetapis.com/v1/requestToken'
 			self.jwt = params['jwt'] if params['jwt']
 			self.refresh_token = params['refresh_token'] if params['refresh_token']
 
@@ -126,7 +127,7 @@ module FuelSDK
 					h['content_type'] = 'application/json'
 					h['params'] = {'legacy' => 1}
 				end
-				response = post("https://auth.exacttargetapis.com/v1/requestToken", options)
+				response = post(request_token_url, options)
 				raise "Unable to refresh token: #{response['message']}" unless response.has_key?('accessToken')
 
 				self.access_token = response['accessToken']

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -21,6 +21,16 @@ describe FuelSDK::Client do
       expect(client.debug).to be_false
     end
 
+    it 'sets the request_token url to parameter if it exists' do
+      client = FuelSDK::Client.new({'request_token_url' => 'fake/url'}, false)
+      expect(client.request_token_url).to eq 'fake/url'
+    end
+
+    it 'sets the request_token url to a default if it does not exist' do
+      client = FuelSDK::Client.new({}, false)
+      expect(client.request_token_url).to eq 'https://auth.exacttargetapis.com/v1/requestToken'
+    end
+
     it 'creates SoapClient' do
       client = FuelSDK::Client.new
       expect(client).to be_kind_of FuelSDK::Soap


### PR DESCRIPTION
Right now the FuelSDK doesn't work with sandbox (AKA Production Support) accounts.

This pull request gives the user the option to override the default request token value for use with sandbox accounts.