### PR TITLE
Remove evil retry

### DIFF
--- a/lib/marketingcloudsdk/rest.rb
+++ b/lib/marketingcloudsdk/rest.rb
@@ -100,22 +100,13 @@ module MarketingCloudSDK
     end
 
     private
-      def rest_request action, url, options={}		
-        retried = false
-        begin
-          #Try to refresh the token and if we do then we need to regenerate the header as well. 
-          self.refresh 
-          (options['params'] ||= {}).merge! 'access_token' => access_token
-          rsp = rest_client.send(action, url, options)
-          raise 'Unauthorized' if rsp.message == 'Unauthorized'
-        rescue
-          raise if retried
-          self.refresh! # ask for forgiveness not, permission
-          retried = true
-          retry
-        end
-          rsp
-      rescue
+      def rest_request action, url, options={}
+        #Try to refresh the token and if we do then we need to regenerate the header as well.
+        self.refresh
+        (options['params'] ||= {}).merge! 'access_token' => access_token
+        rsp = rest_client.send(action, url, options)
+        raise 'Unauthorized' if rsp.message == 'Unauthorized'
+
         rsp
       end
   end

--- a/lib/marketingcloudsdk/soap.rb
+++ b/lib/marketingcloudsdk/soap.rb
@@ -271,17 +271,8 @@ module MarketingCloudSDK
 
 		def soap_request action, message
 			response = action.eql?(:describe) ? DescribeResponse : SoapResponse
-			retried = false
-			begin
-				rsp = soap_client.call(action, :message => message)
-			rescue
-				raise if retried
-				retried = true
-				retry
-			end
-			response.new rsp, self
-		rescue
-			raise if rsp.nil?
+
+			rsp = soap_client.call(action, :message => message)
 			response.new rsp, self
 		end
 	end


### PR DESCRIPTION
We've run into an issue with some of the data we send to Marketing Cloud being posted twice (which resultsed in duplicate emails send to our customers).

The reason for this is a `retry` in the SOAP and REST interfaces. This PR removes that.