### PR TITLE
Reduce WSDL requests

### DIFF
--- a/lib/marketingcloudsdk/soap.rb
+++ b/lib/marketingcloudsdk/soap.rb
@@ -136,7 +136,7 @@ module MarketingCloudSDK
 
 		def soap_client
 			self.refresh
-			@soap_client = Savon.client(
+			@soap_client ||= Savon.client(
 				soap_header: header,
 				wsdl: wsdl,
 				endpoint: endpoint,


### PR DESCRIPTION
Each time a request is made the the Marketing Cloud API, the WSDL is fetched, creating a significant performance hit in the case of a lot of requests.

By creating and reusing the `Savon::Client` instance, we only make one initial WSDL request.