### PR TITLE
Fix SOAP request formation for continues

### DIFF
--- a/lib/marketingcloudsdk/soap.rb
+++ b/lib/marketingcloudsdk/soap.rb
@@ -42,7 +42,7 @@ module MarketingCloudSDK
 		def continue
 			rsp = nil
 			if more?
-				rsp = unpack @client.soap_client.call(:retrieve, :message => {'ContinueRequest' => request_id})
+				rsp = unpack @client.soap_client.call(:retrieve, :message => {'RetrieveRequest' => {'ContinueRequest' => request_id}})
 			else
 				puts 'No more data'
 			end


### PR DESCRIPTION
#### Description
The Salesforce Marketing Cloud API has a limitation of returning a max of 2500 records per call. As per their documentation, such requests return results where the `more` attribute is set to true, after which you should be able to call `continue` to retrieve the next set of 2500 records. This feature does not work as expected.

References:

1. https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/continuerequest_2500records.htm
2. https://github.com/salesforce-marketingcloud/FuelSDK-Ruby/blob/99f2fb0462180d3abe8bc81eb0bf0d434d63e5e3/samples/sample-bounceevent.rb#L29

#### Environment
```
ruby '2.3.1'
gem 'marketingcloudsdk`, `1.0.0`
gem 'rails', '4.2.7.1`
```

#### Steps to reproduce
The reproduction requires a sample SFMC environment with an object (in this case, a DataExtension row) with greater than 2500 records.
```
require 'marketingcloudsdk'

class SfmcButler
  attr_reader :response
  DATA_EXTENSION_NAME = 'DUMMY_EXTENSION_NAME'.freeze
  DATA_EXTENSION_PROPS = ["PROP_1", "PROP_2"].freeze

  def initialize
    @client = MarketingCloudSDK::Client.new({'client' => { 'id' => ENV['SFMC_CLIENT_ID'], 'secret' => ENV['SFMC_SECRET'] }})
    @dataextensionrow = MarketingCloudSDK::DataExtension::Row.new
    @dataextensionrow.authStub = @client
    @dataextensionrow.Name = DATA_EXTENSION_NAME
    @dataextensionrow.props = DATA_EXTENSION_PROPS
  end

  def get_response
    @response = @dataextensionrow.get
  end

  def get_more_responses
    @response = @response.continue
  end
end
```

The initial `get` call runs successfully, forming the following XML and returning the first 2500 results:
```
<?xml version="1.0" encoding="UTF-8"?>
<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://exacttarget.com/wsdl/partnerAPI" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
  <env:Header>
      <HEADER INFO HERE>
  </env:Header>
  <env:Body>
    <tns:RetrieveRequestMsg>
      <tns:RetrieveRequest>
        <tns:ObjectType>DataExtensionObject[DUMMY_EXTENSION_NAME]</tns:ObjectType>
        <tns:Properties>PROP_1</tns:Properties>
        <tns:Properties>PROP_2</tns:Properties>
      </tns:RetrieveRequest>
    </tns:RetrieveRequestMsg>
  </env:Body>
</env:Envelope>
```
```
@butler.get_response
> ... # Yields the first 2500 responses as expected
@butler.response.class
> MarketingCloudSDK::SoapResponse
@butler.response.more?
> true
@butler.continue
> ... # Yields an array
```

Further inspection reveals that `continue` sends the following XML:
```
<?xml version="1.0" encoding="UTF-8"?>
  <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://exacttarget.com/wsdl/partnerAPI" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
    <env:Header>
      <HEADER INFO HERE>
    </env:Header>
    <env:Body>
      <tns:RetrieveRequestMsg>
        <tns:ContinueRequest><ORIGINAL REQUEST ID HERE></tns:ContinueRequest>
      </tns:RetrieveRequestMsg>
    </env:Body>
  </env:Envelope>
```

This returns an error -- an XML with an unclear error message: "OverallStatus => Error"

Comparing the `continue`-generated request XML with the one generated by the `getMoreRequests` method in the Python SDK reveals that the XML body is malformed. For reference, calling `getMoreRequests` on a result through the Python SDK sends the following XML
```
...
<ns1:Body>
  <ns0:RetrieveRequestMsg>
    <ns0:RetrieveRequest>
      <ns0:ObjectType/>
      <ns0:ContinueRequest><ORIGINAL REQUEST ID></ns0:ContinueRequest>
      </ns0:RetrieveRequest>
  </ns0:RetrieveRequestMsg>
</ns1:Body>
...
```

This change corrects the `continue` method to perform as expected in the docs.

