### PR TITLE
Implemented defaults fallback when REST and Auth endpoints are empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+samples/soap_cache_file.json
 
 # YARD artifacts
 .yardoc

--- a/lib/marketingcloudsdk/client.rb
+++ b/lib/marketingcloudsdk/client.rb
@@ -102,8 +102,8 @@ module MarketingCloudSDK
         self.id = client_config["id"]
         self.secret = client_config["secret"]
         self.signature = client_config["signature"]
-				self.base_api_url = client_config["base_api_url"] ? client_config["base_api_url"] : 'https://www.exacttargetapis.com'
-				self.request_token_url = client_config["request_token_url"] ? client_config["request_token_url"] : 'https://auth.exacttargetapis.com/v1/requestToken'
+				self.base_api_url = !(client_config["base_api_url"].strip.empty?) ? client_config["base_api_url"] : 'https://www.exacttargetapis.com'
+				self.request_token_url = !(client_config["request_token_url"].strip.empty?) ? client_config["request_token_url"] : 'https://auth.exacttargetapis.com/v1/requestToken'
 				self.soap_endpoint = client_config["soap_endpoint"]
 			end
 

--- a/lib/marketingcloudsdk/client.rb
+++ b/lib/marketingcloudsdk/client.rb
@@ -102,8 +102,8 @@ module MarketingCloudSDK
         self.id = client_config["id"]
         self.secret = client_config["secret"]
         self.signature = client_config["signature"]
-				self.base_api_url = !(client_config["base_api_url"].strip.empty?) ? client_config["base_api_url"] : 'https://www.exacttargetapis.com'
-				self.request_token_url = !(client_config["request_token_url"].strip.empty?) ? client_config["request_token_url"] : 'https://auth.exacttargetapis.com/v1/requestToken'
+				self.base_api_url = !(client_config["base_api_url"].to_s.strip.empty?) ? client_config["base_api_url"] : 'https://www.exacttargetapis.com'
+				self.request_token_url = !(client_config["request_token_url"].to_s.strip.empty?) ? client_config["request_token_url"] : 'https://auth.exacttargetapis.com/v1/requestToken'
 				self.soap_endpoint = client_config["soap_endpoint"]
 			end
 

--- a/lib/marketingcloudsdk/http_request.rb
+++ b/lib/marketingcloudsdk/http_request.rb
@@ -37,7 +37,6 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 require 'open-uri'
 require 'net/https'
 require 'json'
-require 'openssl'
 require 'marketingcloudsdk/version'
 
 module MarketingCloudSDK
@@ -98,11 +97,8 @@ module MarketingCloudSDK
 
     def request(method, url, options={})
       uri = generate_uri url, options['params']
-      http = Net::HTTP.new(uri.host, uri.port, '127.0.0.1', '8888')
+      http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      #http = Net::HTTP.new(uri.host, uri.port)
-      #http.use_ssl = true
 
       data = options['data']
       _request = method.new uri.request_uri

--- a/lib/marketingcloudsdk/soap.rb
+++ b/lib/marketingcloudsdk/soap.rb
@@ -139,8 +139,6 @@ module MarketingCloudSDK
 		def soap_client
 			self.refresh
 			@soap_client = Savon.client(
-        ssl_verify_mode: :none,
-        proxy: 'http://127.0.0.1:8888',
 				soap_header: header,
 				wsdl: wsdl,
 				endpoint: endpoint,

--- a/spec/default_values_fallback_spec.rb
+++ b/spec/default_values_fallback_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe MarketingCloudSDK::Client do
+
+  context 'Empty string REST endpoint, no Auth attribute' do
+
+    client1 = MarketingCloudSDK::Client.new 'client' => {'id' => '1234', 'secret' => 'ssssh',
+                                                        'base_api_url' => ''}
+
+    it 'Should use REST endpoint default value if base_api_url endpoint is an empty string in config' do
+      expect(client1.base_api_url).to eq 'https://www.exacttargetapis.com'
+    end
+
+    it 'Should use Auth endpoint default value if request_token_url attribute is not in config' do
+      expect(client1.request_token_url).to eq 'https://auth.exacttargetapis.com/v1/requestToken'
+    end
+  end
+
+  context 'Blank string REST endpoint' do
+
+    client2 = MarketingCloudSDK::Client.new 'client' => {'id' => '1234', 'secret' => 'ssssh',
+                                                         'base_api_url' => '   '}
+
+    it 'Should use REST endpoint default value if REST endpoint is a blank string in config' do
+      expect(client2.base_api_url).to eq 'https://www.exacttargetapis.com'
+    end
+
+  end
+
+end


### PR DESCRIPTION
Implemented defaults fallback when REST and Auth endpoints are empty strings, addded soap_cache_file.json to gitignore, removed proxy settings for tracking