### PR TITLE
Open up dependencies

### DIFF
--- a/marketingcloudsdk.gemspec
+++ b/marketingcloudsdk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 	spec.add_development_dependency "guard",'~> 1.1'
 	spec.add_development_dependency "guard-rspec",'~> 2.0'
 
-	spec.add_dependency "savon", "2.2.0"
-	spec.add_dependency "json", "~>1.8",">= 1.8.1" 
-	spec.add_dependency "jwt", "~>1.0",">= 1.0.0"
+	spec.add_dependency "savon", "~> 2.12.1"
+	spec.add_dependency "json", "~> 2.3"
+	spec.add_dependency "jwt", "~> 2.2"
 end


### PR DESCRIPTION
This will allow fuel sdk to be used with recent versions of gems.